### PR TITLE
more current limits

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -119,7 +119,7 @@ export const ICONS = {
   'sensor.voltage': 'mdi:sine-wave',
 };
 
-export const CURRENTLIMITS = [8.0, 10.0, 16.0, 20.0, 25.0, 32.0];
+export const CURRENTLIMITS = [6.0, 8.0, 10.0, 12.0, 16.0, 20.0, 25.0, 32.0];
 
 export const DEFAULT_CUSTOMCARDTHEME = 'theme_default';
 export const CUSTOM_CARD_THEMES = [


### PR DESCRIPTION
I believe most cars that can take 3-phase can also charge with a lower current than 8A (tested with a Kia so far). And since not everyone have a Equalizer installed I think it is sometimes useful to be able to reduce the charge current down to 6A and also have a 12A option. 

So I added 6.0A and 12.0A to list of selectable Current Limits.