### PR TITLE
Update en-GB.json

### DIFF
--- a/src/localize/languages/en-GB.json
+++ b/src/localize/languages/en-GB.json
@@ -1,14 +1,14 @@
 {
   "common": {
     "name": "Charger Card",
-    "description": "Charger card allows you to control your EV homecharger (or something else).",
+    "description": "Charger card lets you control your EV homecharger (or something else).",
     "version": "Version",
     "invalid_configuration": "Invalid configuration",
     "show_warning": "Show Warning",
     "show_error": "Show Error"
   },
   "error": {
-    "missing_entity": "Specifying entity is required!",
+    "missing_entity": "Entity specification required!",
     "not_available": "Not available",
     "missing_config": "Error in config!",
     "missing_group": "No entities defined in group!"
@@ -19,12 +19,12 @@
     "unavailable" : "unavailable"
   },
   "editor": {
-    "instruction": "Select your main entity and type/brand. The card will automatically try to detect the other sensors. If you have a brand which is not supported by default, you can choose «Other» and do mapping of entities manually. If anything fails, please verify the YAML configuration (click «Show code editor»).",
+    "instruction": "Select your primary entity and type/brand. The card will automatically attempt to detect the other sensors. If your brand isn't supported by default, you can choose «Other» and map entities manually. If anything goes wrong, please check the YAML configuration (click «Show code editor»).",
     "brand": "Brand/Template (Required)",
     "entity": "Main Entity (Required)",
-    "chargerImage": "Built-in images and color",
+    "chargerImage": "Built-in images and colour",
     "customImage": "Custom image (Optional - overrides charger image)",
-    "theme": "Color theme",
+    "theme": "Colour theme",
     "compact_view": "Compact View",
     "compact_view_aria_label_on": "Toggle compact view on",
     "compact_view_aria_label_off": "Toggle compact view off",


### PR DESCRIPTION
The en-GB.json provided appears to be written in American English. The differences between American English (en-US) and British English (en-GB) often involve spelling, terminology, and occasionally punctuation, but not so much in syntax or grammar. In the case of the provided JSON file, most of the text seems to be written in a neutral way that could apply to both American and British English.

However, there are a few phrases that could be more culturally aligned to British English. This PR is the slightly adjusted version with a few cultural changes.

The changes are minimal and mainly involve using a more British English style of phrasing:

In the "description" field, "allows" has been changed to "lets", which might be slightly more common in British English.

In the "instruction" field, "primary" has been used instead of "main", which is a common alternative in British English. "Color" has been changed to "colour" in the "chargerImage" and "theme" fields, reflecting the British English spelling. In the "instruction" field, "attempt" has been used instead of "try", and "goes wrong" instead of "fails", to align more with British English phrasing. Remember, these changes are very subtle and may not even be necessary. The original text was already in a very clear and neutral form of English that would be understood by speakers of both American and British English.

The rest of the JSON file could remain the same, as it is not specific to any particular dialect of English. It is important to note that most of the text here is quite technical and specific to the application itself (like error messages, status updates, etc.), which would generally be the same across different English dialects.